### PR TITLE
refactor: replace the default method of `PkgState` with Default derive

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -52,7 +52,7 @@ impl Manifest {
         let pkg_name = receipt.name.clone();
         let version = receipt.version.clone();
 
-        let state = self.pkgs.entry(pkg_name).or_insert_with(PkgState::default);
+        let state = self.pkgs.entry(pkg_name).or_default();
         state.versions.insert(version.clone(), receipt);
         state.current_version = Some(version);
     }

--- a/src/package.rs
+++ b/src/package.rs
@@ -74,7 +74,7 @@ impl PkgDef {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct PkgState {
     // none means installed but not linked
     pub current_version: Option<String>,
@@ -84,8 +84,6 @@ pub struct PkgState {
 }
 
 impl PkgState {
-    pub fn default() -> Self { Self { current_version: None, versions: HashMap::new() } }
-
     /// Get the latest **installed** version from PkgState
     pub fn get_latest_version(&self) -> Option<String> {
         self.versions


### PR DESCRIPTION
### Why?

the default method of `PkgState` is as same as `Default` derive
